### PR TITLE
[node] Run the action on node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ inputs:
     description: The Url of your symbol server (defaults to https://artifacts.dev.azure.com)
     default: 'https://artifacts.dev.azure.com'
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Both node12 and node16 are deprecated, resulting in the action being run on node20 already.

Fixes #35